### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cabal.project.local~
 
 .vscode
 .ghci
+result

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Hackage](https://img.shields.io/hackage/v/sparse-merkle-trees)](https://hackage.haskell.org/package/sparse-merkle-trees)
 [![BSD3](https://img.shields.io/github/license/tochicool/sparse-merkle-trees)](https://github.com/tochicool/sparse-merkle-trees/blob/master/LICENSE)
 
-A Haskell library implementing sparse Merkle trees, an authenticated data 
-structure with support for zero-knowledge proofs of *inclusion and exclusion*, 
+A Haskell library implementing sparse Merkle trees, an authenticated data
+structure with support for zero-knowledge proofs of *inclusion and exclusion*,
 parametrised over cryptographic hash algorithms at the type level.
 
 
@@ -13,18 +13,18 @@ parametrised over cryptographic hash algorithms at the type level.
 
 ## Introduction
 
-A [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) is an authenticated 
-data structure which supports efficient zero-knowledge proofs of element 
+A [Merkle tree](https://en.wikipedia.org/wiki/Merkle_tree) is an authenticated
+data structure which supports efficient zero-knowledge proofs of element
 inclusion from a Merkle root.
 
-A sparse Merkle tree (SMT) is Merkle Tree where all possible keys (digests) are 
-at the leaves of the tree. This gives us the additional properties over a Merkle 
+A sparse Merkle tree (SMT) is Merkle Tree where all possible keys (digests) are
+at the leaves of the tree. This gives us the additional properties over a Merkle
 tree:
 
 * support for proofs of *exclusion* of elements from a Merkle root
 * *history independence* of the merkle root from element insertion order
 
-A naive construction would mean that a N-bit key would yield a SMT of size 
+A naive construction would mean that a N-bit key would yield a SMT of size
 2^N. However, because the tree is *sparse*, there are efficient constructions
 that grow in size O(n) where n is the size of the tree.
 
@@ -41,9 +41,9 @@ SMTs expand on the existing use cases of Merkle trees including:
 
 ### Compact Sparse Merkle Trees
 
-The compact sparse Merkle tree is based on the description given in this 
-[report](https://eprint.iacr.org/2018/955.pdf) by 
-[Faraz Haider](https://github.com/farazhaider). The module exposes an similar 
+The compact sparse Merkle tree is based on the description given in this
+[report](https://eprint.iacr.org/2018/955.pdf) by
+[Faraz Haider](https://github.com/farazhaider). The module exposes an similar
 API to [`Data.Set`](https://hackage.haskell.org/package/containers-0.6.5.1/docs/Data-Set.html) but this is subject to change.
 
 ```haskell
@@ -126,5 +126,5 @@ See the more complete haddock documentation on [Hackage](https://hackage.haskell
 
 ## Related libraries
 
-* [cryptonite](https://hackage.haskell.org/package/cryptonite) for cryptographic primitives
+* [crypton](https://hackage.haskell.org/package/crypton) for cryptographic primitives
 * [merkle-tree](https://hackage.haskell.org/package/merkle-tree) for an implementation of a merkle tree

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,668 @@
+{
+  "nodes": {
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1762440070,
+        "narHash": "sha256-xxdepIcb39UJ94+YydGP221rjnpkDZUlykKuF54PsqI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "26d05891e14c88eb4a5d5bee659c0db5afb609d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681378341,
+        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
+        "owner": "hamishmack",
+        "repo": "flake-utils",
+        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hamishmack",
+        "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1762561447,
+        "narHash": "sha256-cIzA3oVThdRAKwFWfld+8HKS6yeOlxmmTiL7eRFNbDk=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "3790462042f98c3fc264ce39a3fcc5ace843fc3b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1762561438,
+        "narHash": "sha256-gjYC9eWxBhfNU+MnbXdTZIJqM3kEw+8/Lw0Sy61KiM4=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "a55381cbf5a56ac69fdb568c80c8e3d2d840459f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
+        "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
+        "hpc-coveralls": "hpc-coveralls",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1762563126,
+        "narHash": "sha256-EOds/CW2Lg3SmkJ9c9V0t0FB1xBtuiaJFlkaSXQFPnk=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "7a652487e84f74ca32cc1a16e77c2915a8da1096",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1757716134,
+        "narHash": "sha256-OYoZLWvmCnCTCJQwaQlpK1IO5nkLnLLoUW8wwmPmrfU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e85b5aa112a98805a016bbf6291e726debbc448a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "flake-utils": "flake-utils",
+        "haskellNix": "haskellNix",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1762560769,
+        "narHash": "sha256-srSwB2Csn6yHUT0efxEG9DNFqO5jGojX8eXUjXf9yhE=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "23e18e78d743db21094c8e0e6484575680ec57f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "Sparse Merkle Trees implementation in Haskell";
+  nixConfig = {
+    extra-substituters = [ "https://cache.iog.io" ];
+    extra-trusted-public-keys =
+      [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
+  };
+  inputs = {
+    haskellNix.url = "github:input-output-hk/haskell.nix";
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-utils, haskellNix, ... }:
+    let
+      lib = nixpkgs.lib;
+      version = self.dirtyShortRev or self.shortRev;
+
+      perSystem = system:
+        let
+          pkgs = import nixpkgs {
+            overlays = [
+              haskellNix.overlay # some functions
+            ];
+            inherit system;
+          };
+          project = import ./nix/project.nix {
+            indexState = "2025-08-07T00:00:00Z";
+            inherit pkgs;
+          };
+
+          info.packages = { inherit version; };
+
+          fullPackages = lib.mergeAttrsList [
+            info.packages
+            project.packages
+          ];
+
+        in {
+          inherit project;
+          packages = fullPackages;
+          inherit (project) devShells;
+        };
+
+    in flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" ] perSystem;
+}

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,0 +1,43 @@
+{ indexState, pkgs, ... }:
+
+let
+  libOverlay = { lib, pkgs, ... }:
+    {
+
+    };
+
+  shell = { pkgs, ... }: {
+    tools = {
+      cabal = { index-state = indexState; };
+      cabal-fmt = { index-state = indexState; };
+      haskell-language-server = { index-state = indexState; };
+      hoogle = { index-state = indexState; };
+      fourmolu = { index-state = indexState; };
+      hlint = { index-state = indexState; };
+    };
+    withHoogle = true;
+    buildInputs = [
+      pkgs.gitAndTools.git
+      pkgs.just
+      pkgs.nixfmt-classic
+
+    ];
+    shellHook = ''
+      echo "Entering shell for sparse-merkle-tree development"
+    '';
+  };
+
+  mkProject = ctx@{ lib, pkgs, ... }: {
+    name = "sparse-merkle-trees";
+    src = ./..;
+    compiler-nix-name = "ghc984";
+    shell = shell { inherit pkgs; };
+    modules = [ libOverlay ];
+  };
+  project = pkgs.haskell-nix.cabalProject' mkProject;
+
+in {
+  devShells.default = project.shell;
+  packages.sparse-merkle-trees = project.hsPkgs.sparse-merkle-trees.components.library;
+  inherit project;
+}

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ dependencies:
   - bytestring       >= 0.10 && < 0.12
   - containers       >= 0.6  && < 0.7
   - cryptonite       >= 0.25 && < 0.31
-  - memory           >= 0.14 && < 0.18
+  - memory           >= 0.14 && < 0.19
 ghc-options:
   - -Wall
 library:

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ dependencies:
   - base             >= 4.7  && < 5
   - bytestring       >= 0.10 && < 0.12
   - containers       >= 0.6  && < 0.7
-  - cryptonite       >= 0.25 && < 0.31
+  - crypton
   - memory           >= 0.14 && < 0.19
 ghc-options:
   - -Wall

--- a/sparse-merkle-trees.cabal
+++ b/sparse-merkle-trees.cabal
@@ -38,7 +38,7 @@ library
       base >=4.7 && <5
     , bytestring >=0.10 && <0.12
     , containers ==0.6.*
-    , cryptonite >=0.25 && <0.31
+    , crypton
     , memory >=0.14 && <0.19
   default-language: Haskell2010
 
@@ -54,7 +54,7 @@ test-suite sparse-merkle-trees-test
       base >=4.7 && <5
     , bytestring >=0.10 && <0.12
     , containers ==0.6.*
-    , cryptonite >=0.25 && <0.31
+    , crypton
     , memory >=0.14 && <0.19
     , smallcheck
     , sparse-merkle-trees
@@ -78,7 +78,7 @@ benchmark sparse-merkle-trees-bench
     , bytestring >=0.10 && <0.12
     , containers ==0.6.*
     , criterion
-    , cryptonite >=0.25 && <0.31
+    , crypton
     , deepseq
     , memory >=0.14 && <0.19
     , sparse-merkle-trees

--- a/sparse-merkle-trees.cabal
+++ b/sparse-merkle-trees.cabal
@@ -35,11 +35,14 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      base >=4.7 && <5
-    , bytestring >=0.10 && <0.12
-    , containers ==0.6.*
+      base
+    , bytestring
+    , containers
     , crypton
-    , memory >=0.14 && <0.19
+    , memory
+    , rocksdb-haskell-jprupp
+    , unliftio
+
   default-language: Haskell2010
 
 test-suite sparse-merkle-trees-test
@@ -51,11 +54,11 @@ test-suite sparse-merkle-trees-test
       test
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
-    , bytestring >=0.10 && <0.12
-    , containers ==0.6.*
+      base
+    , bytestring
+    , containers
     , crypton
-    , memory >=0.14 && <0.19
+    , memory
     , smallcheck
     , sparse-merkle-trees
     , tasty
@@ -74,12 +77,12 @@ benchmark sparse-merkle-trees-bench
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck
-    , base >=4.7 && <5
-    , bytestring >=0.10 && <0.12
-    , containers ==0.6.*
+    , base
+    , bytestring
+    , containers
     , criterion
     , crypton
     , deepseq
-    , memory >=0.14 && <0.19
+    , memory
     , sparse-merkle-trees
   default-language: Haskell2010

--- a/sparse-merkle-trees.cabal
+++ b/sparse-merkle-trees.cabal
@@ -39,7 +39,7 @@ library
     , bytestring >=0.10 && <0.12
     , containers ==0.6.*
     , cryptonite >=0.25 && <0.31
-    , memory >=0.14 && <0.18
+    , memory >=0.14 && <0.19
   default-language: Haskell2010
 
 test-suite sparse-merkle-trees-test
@@ -55,7 +55,7 @@ test-suite sparse-merkle-trees-test
     , bytestring >=0.10 && <0.12
     , containers ==0.6.*
     , cryptonite >=0.25 && <0.31
-    , memory >=0.14 && <0.18
+    , memory >=0.14 && <0.19
     , smallcheck
     , sparse-merkle-trees
     , tasty
@@ -80,6 +80,6 @@ benchmark sparse-merkle-trees-bench
     , criterion
     , cryptonite >=0.25 && <0.31
     , deepseq
-    , memory >=0.14 && <0.18
+    , memory >=0.14 && <0.19
     , sparse-merkle-trees
   default-language: Haskell2010

--- a/src/Crypto/Hash/CompactSparseMerkleTree.hs
+++ b/src/Crypto/Hash/CompactSparseMerkleTree.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE TypeSynonymInstances, StrictData #-}
 
 -- |
 -- Module      : Crypto.Hash.CompactSparseMerkleTree

--- a/src/Crypto/Hash/CompactSparseMerkleTree/DataNode.hs
+++ b/src/Crypto/Hash/CompactSparseMerkleTree/DataNode.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE StrictData #-}
 module Crypto.Hash.CompactSparseMerkleTree.DataNode where
+
 import Crypto.Hash (Digest)
 
 data DataNode alg a


### PR DESCRIPTION
Bump GitHub Actions to Node.js 24 compatible versions. Node.js 20 is deprecated June 2026.